### PR TITLE
Add installation for 'but' binary

### DIFF
--- a/gitbutler.nix
+++ b/gitbutler.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm755 unpack/usr/bin/gitbutler-tauri $out/bin/gitbutler-tauri
     install -Dm755 unpack/usr/bin/gitbutler-git-setsid $out/bin/gitbutler-git-setsid
     install -Dm755 unpack/usr/bin/gitbutler-git-askpass $out/bin/gitbutler-git-askpass
+    install -Dm755 unpack/usr/bin/but $out/bin/but
 
     cp -r unpack/usr/share $out/share
   '';


### PR DESCRIPTION
This update includes the `but` cli tool. This is a required dependency to use Claude Code with Gitbutler.