### PR TITLE
Bump to gitbutler 0.17.1 and address breaking change

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760284886,
-        "narHash": "sha256-TK9Kr0BYBQ/1P5kAsnNQhmWWKgmZXwUQr4ZMjCzWf2c=",
+        "lastModified": 1761672384,
+        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cf3f5c4def3c7b5f1fc012b3d839575dbe552d43",
+        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
         "type": "github"
       },
       "original": {

--- a/gitbutler.nix
+++ b/gitbutler.nix
@@ -36,7 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm755 unpack/usr/bin/gitbutler-tauri $out/bin/gitbutler-tauri
     install -Dm755 unpack/usr/bin/gitbutler-git-setsid $out/bin/gitbutler-git-setsid
     install -Dm755 unpack/usr/bin/gitbutler-git-askpass $out/bin/gitbutler-git-askpass
-    install -Dm755 unpack/usr/bin/but $out/bin/but
+    ln -s gitbutler-tauri $out/bin/gitbutler
+    ln -s gitbutler-tauri $out/bin/but
 
     cp -r unpack/usr/share $out/share
   '';

--- a/sources.json
+++ b/sources.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.16.10",
+  "version": "0.17.1",
   "x86_64-linux": {
-    "url": "https://releases.gitbutler.com/releases/release/0.16.10-2482/linux/x86_64/GitButler_0.16.10_amd64.deb",
-    "hash": "sha256-5XQxDr1sgwIQc4sAMXP5grhYY8p5k8BFRZynim+Pu38="
+    "url": "https://releases.gitbutler.com/releases/release/0.17.1-2540/linux/x86_64/GitButler_0.17.1_amd64.deb",
+    "hash": "sha256-RCR7ErTNNKaW9jvJxBowDhTVaF+8xymvNJ/RDe7r/s4="
   }
 }

--- a/sources.json
+++ b/sources.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.17.1",
+  "version": "0.17.2",
   "x86_64-linux": {
-    "url": "https://releases.gitbutler.com/releases/release/0.17.1-2540/linux/x86_64/GitButler_0.17.1_amd64.deb",
-    "hash": "sha256-RCR7ErTNNKaW9jvJxBowDhTVaF+8xymvNJ/RDe7r/s4="
+    "url": "https://releases.gitbutler.com/releases/release/0.17.2-2545/linux/x86_64/GitButler_0.17.2_amd64.deb",
+    "hash": "sha256-CQKCtAMgrQ0Kqe2N8PRnnKGppYKT3tBiiy5NQqhOWAA="
   }
 }


### PR DESCRIPTION
`but` is no longer a standalone binary as of 0.17, so create a symlink to gitbutler-tauri, which now acts as a single binary for the desktop application and CLI. Also, create a 'gitbutler' symlink for good measure.